### PR TITLE
prevent negative length memmove copy

### DIFF
--- a/src/plugins/lanplus/lanplus.c
+++ b/src/plugins/lanplus/lanplus.c
@@ -792,7 +792,7 @@ ipmi_lan_poll_single(struct ipmi_intf * intf)
 			 * rsp->data_len becomes the length of that data
 			 */
 			extra_data_length = payload_size - (offset - payload_start) - 1;
-			if (extra_data_length) {
+			if (extra_data_length > 0) {
 				rsp->data_len = extra_data_length;
 				memmove(rsp->data, rsp->data + offset, extra_data_length);
 			} else {
@@ -846,7 +846,7 @@ ipmi_lan_poll_single(struct ipmi_intf * intf)
 		}
 		read_sol_packet(rsp, &offset);
 		extra_data_length = payload_size - (offset - payload_start);
-		if (rsp && extra_data_length) {
+		if (rsp && extra_data_length > 0) {
 			rsp->data_len = extra_data_length;
 			memmove(rsp->data, rsp->data + offset, extra_data_length);
 		} else {


### PR DESCRIPTION
Discovered using a dcmi power reading command that attempts to return an error 'DCMI request failed because: Request data truncated (c6)'. The function lanplus_crypt.c lanplus_decrypt_payload will decrypt a shorter data length of 7 rather than the expected length of 8 bytes, causing ipmi_lan_poll_single() to incorrectly assume the extra_data_length of -1 should trigger a memmove of rsp->data to rsp->data + offset. This results in a segv in the memmove library. The correction is to test for a positive size of extra_data_length.